### PR TITLE
First fix for bad connection 

### DIFF
--- a/client/lua-corona/noobhub.lua
+++ b/client/lua-corona/noobhub.lua
@@ -45,8 +45,10 @@ noobhub = {
 		end
 
 		function self:unsubscribe()
+			if self.sock then
 				self.sock:close()
 				self.sock = nil
+			end
 				self.buffer = ''
 		end
 


### PR DESCRIPTION
On a very bad connection this error can occur: "attempt to index field
'sock' (a nil value)"

Should fix issue #5.
