### PR TITLE
refactoring of terminator strings; http endpoint to list clients per channel

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "none",
+  "singleQuote": true,
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ NoobHub
 
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
-OpenSource multiplayer and network messaging for CoronaSDK, Moai, Gideros & LÖVE
+OpenSource multiplayer and network messaging for CoronaSDK, Moai, Gideros, LÖVE & Defold
 
 Battle-tested and production ready. Handling thousands of CCU (concurrent users), serving hundreds of thousands multiplayer games daily, routing hundreds of messages per second, with months of uptime.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Battle-tested and production ready. Handling thousands of CCU (concurrent users)
 - Connections are routed through socket server with minimum latency, ideal for action games.
 - Simple interface. Publish/subscribe paradigm in action.
 - Server written on blazing fast Nodejs.
-- Zero dependency. Works out of the box, no NPM ecosystem required.
+- Zero dependency. Works out of the box, no NPM ecosystem required. (for websocket bridge relies on `ws` module, read below)
 - Socket connections, works great through any NAT (local area network), messages delivery is reliable and fast.
 - Low CPU and memory footprint
 
@@ -60,7 +60,7 @@ hub.subscribe({
   channel: 'hello-world',
   callback: (data) => {
     console.log('callback', data);
-  },
+  }
 });
 ```
 
@@ -78,7 +78,7 @@ SAY SOMETHING TO EVERYBODY ON THE CHANNEL
 ```js
 hub.publish({
   action: 'ping',
-  timestamp: Date.now(),
+  timestamp: Date.now()
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-NoobHub
-=======
+# NoobHub
 
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
@@ -7,33 +6,42 @@ OpenSource multiplayer and network messaging for CoronaSDK, Moai, Gideros, LÖVE
 
 Battle-tested and production ready. Handling thousands of CCU (concurrent users), serving hundreds of thousands multiplayer games daily, routing hundreds of messages per second, with months of uptime.
 
-* Connections are routed through socket server with minimum latency, ideal for action games.
-* Simple interface. Publish/subscribe paradigm in action.
-* Server written on blazing fast Nodejs.
-* Zero dependency. Works out of the box, no NPM ecosystem required.
-* Socket connections, works great through any NAT (local area network), messages delivery is reliable and fast.
-* Low CPU and memory footprint
+- Connections are routed through socket server with minimum latency, ideal for action games.
+- Simple interface. Publish/subscribe paradigm in action.
+- Server written on blazing fast Nodejs.
+- Zero dependency. Works out of the box, no NPM ecosystem required.
+- Socket connections, works great through any NAT (local area network), messages delivery is reliable and fast.
+- Low CPU and memory footprint
 
 Repo includes server code (so you can use your own server) and CoronaSDK/Moai/Gideros/LÖVE client. More clients to come.
 You can test on my server, credentials are hardcoded in demo project!
 
 Lua code may serve as an example of how LuaSocket library works.
 
-
-How to use it
-------------
+## How to use it
 
 START SERVER
+
 ```bash
         $ nodejs node.js
 ```
 
+To make use of the websocket bridge, uncomment wsPort in the config.  
+If so, make sure to do `npm install` as well.  
+These are useful to serve browser clients. Irrelevant otherwise.
+
 INITIALIZE
+
 ```lua
         hub = noobhub.new({ server = "127.0.0.1"; port = 1337; });
 ```
 
+```js
+const hub = noobhub.new({ server: '127.0.0.1', port: 2337 });
+```
+
 SUBSCRIBE TO A CHANNEL AND RECEIVE CALLBACKS WHEN NEW JSON MESSAGES ARRIVE
+
 ```lua
         hub:subscribe({
           channel = "hello-world";
@@ -46,7 +54,18 @@ SUBSCRIBE TO A CHANNEL AND RECEIVE CALLBACKS WHEN NEW JSON MESSAGES ARRIVE
         	end;
         });
 ```
+
+```js
+hub.subscribe({
+  channel: 'hello-world',
+  callback: (data) => {
+    console.log('callback', data);
+  },
+});
+```
+
 SAY SOMETHING TO EVERYBODY ON THE CHANNEL
+
 ```lua
         hub:publish({
             message = {
@@ -56,18 +75,24 @@ SAY SOMETHING TO EVERYBODY ON THE CHANNEL
         });
 ```
 
+```js
+hub.publish({
+  action: 'ping',
+  timestamp: Date.now(),
+});
+```
 
-Clients
-------
-* CoronaSDK
-* Gideros
-* Moai
-* LÖVE
-* Node.js
-* PHP (debug console only)
+## Clients
 
-Tests
------
+- CoronaSDK
+- Gideros
+- Moai
+- LÖVE
+- Node.js
+- PHP (debug console only)
+- JS / Browser
+
+## Tests
 
 Simple acceptance test uses Nodejs client to test the server itself:
 
@@ -79,25 +104,22 @@ Simple acceptance test uses Nodejs client to test the server itself:
     tests ok
 ```
 
-Getting ready for production use
-------------
+## Getting ready for production use
+
 If you expect more than 1000 concurrent connections, you should increase limits on your server (max open file descriptors,
 max TCP/IP connections) and optionally fine-tune your server's TCP/IP stack.
-To make sure server process stays alive you migh want to use tools such as forever.js or supervisord.
+To make sure server process stays alive you might want to use tools such as forever.js or supervisord.
 
-Authors
--------
+## Authors
 
-* Igor Korsakov
-* Sergii Tsegelnyk
+- Igor Korsakov
+- Sergii Tsegelnyk
 
+## Licence
 
-Licence
--------
 [WTFPL](http://www.wtfpl.net/txt/copying/)
 
-Official discussion thread
----------------------------
+## Official discussion thread
 
-* [old] http://developer.coronalabs.com/code/noobhub
-* [new] http://forums.coronalabs.com/topic/32775-noobhub-free-opensource-multiplayer-and-network-messaging-for-coronasdk
+- [old] http://developer.coronalabs.com/code/noobhub
+- [new] http://forums.coronalabs.com/topic/32775-noobhub-free-opensource-multiplayer-and-network-messaging-for-coronasdk

--- a/client/javascript-browser/client.js
+++ b/client/javascript-browser/client.js
@@ -54,5 +54,5 @@ const noobhub = {
     });
 
     return { publish, subscribe };
-  },
+  }
 };

--- a/client/javascript-browser/client.js
+++ b/client/javascript-browser/client.js
@@ -1,0 +1,58 @@
+function noop() {}
+
+const noobhub = {
+  new: function (cfg) {
+    const ws = new WebSocket(`ws://${cfg.server}:${cfg.port}`);
+
+    let channel;
+    let callback;
+    let errorCallback;
+    let subscribedCallback;
+    let isReady = false;
+
+    function publish(data) {
+      isReady && ws.send(`__JSON__START__${JSON.stringify(data)}__JSON__END__`);
+    }
+
+    function subscribe(o) {
+      channel = o.channel;
+      callback = o.callback;
+      errorCallback = o.errorCallback || noop;
+      subscribedCallback = o.subscribedCallback || noop;
+      isReady &&
+        ws.send(JSON.stringify(`__SUBSCRIBE__${channel}__ENDSUBSCRIBE__`));
+    }
+
+    ws.addEventListener('open', () => {
+      isReady = true;
+      ws.send(JSON.stringify(`__SUBSCRIBE__${channel}__ENDSUBSCRIBE__`));
+      subscribedCallback(ws);
+    });
+
+    ws.addEventListener('message', (rawData) => {
+      let data = rawData.data;
+      try {
+        let start, end;
+        if (
+          (start = data.indexOf('__JSON__START__')) !== -1 &&
+          (end = data.indexOf('__JSON__END__')) !== -1
+        ) {
+          const json = data.substr(start + 15, end - (start + 15));
+          data = JSON.parse(json);
+        }
+      } catch (_) {}
+      callback(data);
+    });
+
+    ws.addEventListener('error', (err) => {
+      errorCallback(err);
+    });
+
+    ws.addEventListener('close', () => {
+      isReady = false;
+      errorCallback('closed');
+    });
+
+    return { publish, subscribe };
+  },
+};

--- a/client/javascript-browser/index.html
+++ b/client/javascript-browser/index.html
@@ -30,7 +30,7 @@
         errorCallback: (err) => {
           console.log('error callback', err);
           process.exit(1);
-        },
+        }
       });
     </script>
   </body>

--- a/client/javascript-browser/index.html
+++ b/client/javascript-browser/index.html
@@ -1,0 +1,37 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>test noobhub websocket client</title>
+  </head>
+  <body>
+    <h1>test noobhub websocket client</h1>
+    <script src="client.js"></script>
+
+    <script>
+      const hub = noobhub.new({ server: 'localhost', port: 2337 });
+
+      const myName = 'js_browser_user_' + Math.floor(1000 * Math.random());
+      const ch = 'ch1';
+      const dt = 2000;
+
+      hub.subscribe({
+        channel: ch,
+        callback: (data) => {
+          console.log('callback', data);
+        },
+        subscribedCallback: () => {
+          console.log('subscribedCallback');
+
+          let i = 0;
+          setInterval(() => {
+            hub.publish({ from: myName, data: `${i++} ${Math.random()}` });
+          }, dt);
+        },
+        errorCallback: (err) => {
+          console.log('error callback', err);
+          process.exit(1);
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/client/javascript-node-js/client.js
+++ b/client/javascript-node-js/client.js
@@ -14,7 +14,7 @@ function _log() {
 const configDef = {
   server: 'localhost',
   port: 1337,
-  channel: 'gsom',
+  channel: 'gsom'
 };
 
 const Noobhub = function (config) {

--- a/client/javascript-node-js/client.js
+++ b/client/javascript-node-js/client.js
@@ -3,105 +3,120 @@
  *
  */
 
-var net = require('net')
-var configDef = {
-  server: 'localhost',
-  port: 1337,
-  channel: 'gsom'
+const net = require('net');
+
+const VERBOSE = true;
+
+function _log() {
+  if (VERBOSE) console.log.apply(console, arguments);
 }
 
-var Noobhub = function (config) {
-  var self = this
+const configDef = {
+  server: 'localhost',
+  port: 1337,
+  channel: 'gsom',
+};
 
-  this.socket = null
-  this.buffer = new Buffer(1024 * 16)
-  this.buffer.len = 0
-  this.messageCallback = null
-  this.errorCallback = null
-  this.subscribedCallback = null
+const Noobhub = function (config) {
+  const self = this;
 
-  this.config = configDef
+  this.socket = null;
+  this.buffer = new Buffer.alloc(1024 * 16);
+  this.buffer.len = 0;
+  this.messageCallback = null;
+  this.errorCallback = null;
+  this.subscribedCallback = null;
 
-  for (var prop in config) {
+  this.config = configDef;
+
+  for (let prop in config) {
     if (self.config.hasOwnProperty(prop)) {
-      self.config[prop] = config[prop]
+      self.config[prop] = config[prop];
     }
   }
 
   self.subscribe = function (config) {
-    for (var prop in config) {
+    for (let prop in config) {
       if (self.config.hasOwnProperty(prop)) {
-        self.config[prop] = config[prop]
+        self.config[prop] = config[prop];
       }
     }
-    self.messageCallback = config.callback || self.messageCallback
-    self.errorCallback = config.errorCallback || self.errorCallback
-    self.subscribedCallback = config.subscribedCallback || self.subscribedCallback
-    self.socket = net.createConnection(self.config.port, self.config.server)
-    self.socket.setNoDelay(true)
-    self.socket._isConnected = false
 
-    self.socket.on('connect', function () {
-      // console.log('connected to ', config.server + ':' + config.port)
-      self.socket.write('__SUBSCRIBE__' + config.channel + '__ENDSUBSCRIBE__', function () {
-        self.socket._isConnected = true
+    self.messageCallback = config.callback || self.messageCallback;
+    self.errorCallback = config.errorCallback || self.errorCallback;
+    self.subscribedCallback =
+      config.subscribedCallback || self.subscribedCallback;
+    self.socket = net.createConnection(self.config.port, self.config.server);
+    self.socket.setNoDelay(true);
+    self.socket._isConnected = false;
 
-        if (typeof (self.subscribedCallback) === 'function') {
-          self.subscribedCallback(self.socket)
+    self.socket.on('connect', () => {
+      _log(`connected to ${self.config.server}:${self.config.port}`);
+      self.socket.write(
+        '__SUBSCRIBE__' + config.channel + '__ENDSUBSCRIBE__',
+        function () {
+          self.socket._isConnected = true;
+
+          if (typeof self.subscribedCallback === 'function') {
+            self.subscribedCallback(self.socket);
+          }
+
+          self.socket.on('data', self._handleIncomingMessage);
         }
+      );
+    });
 
-        self.socket.on('data', self._handleIncomingMessage)
-      })
-    })
+    self.socket.on('error', (err) => {
+      _log('err0r:::', err);
 
-    self.socket.on('error', function (err) {
-      // console.log('err0r:::', err)
-
-      if (typeof (self.errorCallback) === 'function') {
-        return self.errorCallback(err)
+      if (typeof self.errorCallback === 'function') {
+        return self.errorCallback(err);
       } else {
-        return
+        return;
       }
-    })
-  } //  end of self.subscribe()
+    });
+  }; //  end of self.subscribe()
 
   self.publish = function (message, cb) {
     if (!self.socket._isConnected) {
-      return false
+      return false;
     }
 
     if (typeof message !== 'string') {
-      message = JSON.stringify(message)
+      message = JSON.stringify(message);
     }
 
-    this.socket.write('__JSON__START__' + message + '__JSON__END__', cb)
-  }
+    this.socket.write('__JSON__START__' + message + '__JSON__END__', cb);
+  };
 
   self.unsubscribe = function () {
     if (self.socket._isConnected) {
-      self.socket.end('Take care NoobHub...')
-      self.socket._isConnected = false
+      self.socket.end('Take care NoobHub...');
+      self.socket._isConnected = false;
     }
-  }
+  };
 
-  self._handleIncomingMessage = function (data) {
-    self.buffer.len += data.copy(self.buffer, self.buffer.len)
-    var start
-    var end
-    var str = self.buffer.slice(0, self.buffer.len).toString()
+  self._handleIncomingMessage = (data) => {
+    self.buffer.len += data.copy(self.buffer, self.buffer.len);
+    let start;
+    let end;
+    let str = self.buffer.slice(0, self.buffer.len).toString();
 
-    if ((start = str.indexOf('__JSON__START__')) !== -1 && (end = str.indexOf('__JSON__END__')) !== -1) {
-      var json = str.substr(start + 15, end - (start + 15))
-      str = str.substr(end + 13)  // cut the message and remove the precedant part of the buffer since it can't be processed
-      self.buffer.len = self.buffer.write(str, 0)
-      json = JSON.parse(json)
-      if (typeof (self.messageCallback) === 'function') {
-        self.messageCallback(json)
+    if (
+      (start = str.indexOf('__JSON__START__')) !== -1 &&
+      (end = str.indexOf('__JSON__END__')) !== -1
+    ) {
+      var json = str.substr(start + 15, end - (start + 15));
+      str = str.substr(end + 13); // cut the message and remove the precedant part of the buffer since it can't be processed
+      self.buffer.len = self.buffer.write(str, 0);
+      json = JSON.parse(json);
+      if (typeof self.messageCallback === 'function') {
+        self.messageCallback(json);
       }
     }
-  }
-}
+  };
+};
 
-exports.new = function () {
-  return new Noobhub()
-}
+exports.new = function (args = {}) {
+  return new Noobhub(args);
+};

--- a/client/javascript-node-js/client.test.js
+++ b/client/javascript-node-js/client.test.js
@@ -3,38 +3,41 @@
  *
  */
 
-var noobhub = require('./client.js')
-var assert = require('assert')
-var randomData = {rand: Math.random()}
-var iteration = 1
+const assert = require('assert');
+const crypto = require('crypto');
 
-var hub = noobhub.new({server: 'localhost', port: 1337})
+const noobhub = require('./client.js');
 
-setTimeout(function () {
-  console.log('tests NOT ok (timeout)')
-  process.exit(1)
-}, 5000)
+const hub = noobhub.new({ server: 'localhost', port: 1337 });
+
+let randomData = { rand: Math.random() };
+let iteration = 1;
+
+setTimeout(() => {
+  console.log('tests NOT ok (timeout)');
+  process.exit(1);
+}, 5000);
 
 hub.subscribe({
-  channel: 'testChannel' + require('crypto').createHash('md5').update(Math.random().toString()).digest('hex'),
-  callback: function (data) {
-    assert.deepEqual(data, randomData)
+  channel:
+    'testChannel' +
+    crypto.createHash('md5').update(Math.random().toString()).digest('hex'),
+  callback: (data) => {
+    assert.deepEqual(data, randomData);
 
     if (iteration++ < 50) {
-      randomData = {rand: Math.random()}
-      hub.publish(randomData)
+      randomData = { rand: Math.random() };
+      hub.publish(randomData);
     } else {
-      console.log('tests ok')
-      process.exit()
+      console.log('tests ok');
+      process.exit();
     }
   },
-  subscribedCallback: function (socket) {
-    hub.publish(randomData, function () {
-    })
+  subscribedCallback: (socket) => {
+    hub.publish(randomData, () => {});
   },
-  errorCallback: function (err) {
-    console.log('error callback', err)
-    process.exit(1)
-  }
-})
-
+  errorCallback: (err) => {
+    console.log('error callback', err);
+    process.exit(1);
+  },
+});

--- a/client/javascript-node-js/client.test.js
+++ b/client/javascript-node-js/client.test.js
@@ -39,5 +39,5 @@ hub.subscribe({
   errorCallback: (err) => {
     console.log('error callback', err);
     process.exit(1);
-  },
+  }
 });

--- a/client/javascript-node-js/client1.js
+++ b/client/javascript-node-js/client1.js
@@ -22,5 +22,5 @@ hub.subscribe({
   errorCallback: (err) => {
     console.log('error callback', err);
     process.exit(1);
-  },
+  }
 });

--- a/client/javascript-node-js/client1.js
+++ b/client/javascript-node-js/client1.js
@@ -1,0 +1,29 @@
+const noobhub = require('./client');
+
+const hub = noobhub.new({});
+
+const myName = 'user_' + Math.floor(1000 * Math.random());
+const ch = 'ch1';
+const dt = 2000;
+
+hub.subscribe({
+  channel: ch,
+  callback: (data) => {
+    if (data.from === myName) {
+      return;
+    }
+    console.log('callback', data);
+  },
+  subscribedCallback: (socket) => {
+    console.log('subscribedCallback (got socket)');
+
+    let i = 0;
+    setInterval(() => {
+      hub.publish({ from: myName, data: `${i++} ${Math.random()}` });
+    }, dt);
+  },
+  errorCallback: (err) => {
+    console.log('error callback', err);
+    process.exit(1);
+  },
+});

--- a/client/javascript-node-js/client1.js
+++ b/client/javascript-node-js/client1.js
@@ -2,16 +2,13 @@ const noobhub = require('./client');
 
 const hub = noobhub.new({});
 
-const myName = 'user_' + Math.floor(1000 * Math.random());
+const myName = 'js_node_user_' + Math.floor(1000 * Math.random());
 const ch = 'ch1';
 const dt = 2000;
 
 hub.subscribe({
   channel: ch,
   callback: (data) => {
-    if (data.from === myName) {
-      return;
-    }
     console.log('callback', data);
   },
   subscribedCallback: (socket) => {

--- a/client/javascript-node-js/client2.js
+++ b/client/javascript-node-js/client2.js
@@ -22,5 +22,5 @@ hub.subscribe({
   errorCallback: (err) => {
     console.log('error callback', err);
     process.exit(1);
-  },
+  }
 });

--- a/client/javascript-node-js/client2.js
+++ b/client/javascript-node-js/client2.js
@@ -2,16 +2,13 @@ const noobhub = require('./client');
 
 const hub = noobhub.new({});
 
-const myName = 'user_' + Math.floor(1000 * Math.random());
+const myName = 'js_node_user_' + Math.floor(1000 * Math.random());
 const ch = 'ch1'; // 'ch2'
 const dt = 1000;
 
 hub.subscribe({
   channel: ch,
   callback: (data) => {
-    if (data.from === myName) {
-      return;
-    }
     console.log('callback', data);
   },
   subscribedCallback: (socket) => {

--- a/client/javascript-node-js/client2.js
+++ b/client/javascript-node-js/client2.js
@@ -1,0 +1,29 @@
+const noobhub = require('./client');
+
+const hub = noobhub.new({});
+
+const myName = 'user_' + Math.floor(1000 * Math.random());
+const ch = 'ch1'; // 'ch2'
+const dt = 1000;
+
+hub.subscribe({
+  channel: ch,
+  callback: (data) => {
+    if (data.from === myName) {
+      return;
+    }
+    console.log('callback', data);
+  },
+  subscribedCallback: (socket) => {
+    console.log('subscribedCallback (got socket)');
+
+    let i = 0;
+    setInterval(() => {
+      hub.publish({ from: myName, data: `${i++} ${Math.random()}` });
+    }, dt);
+  },
+  errorCallback: (err) => {
+    console.log('error callback', err);
+    process.exit(1);
+  },
+});

--- a/client/lua-love/README.md
+++ b/client/lua-love/README.md
@@ -1,0 +1,4 @@
+- install love2d app
+- place it in applications
+
+  /Applications/love.app/Contents/MacOS/love .

--- a/client/lua-love/main.lua
+++ b/client/lua-love/main.lua
@@ -9,7 +9,8 @@
 
 require("noobhub")
 latencies = {}
-hub = noobhub.new({ server = "46.4.76.236"; port = 1337; });
+-- hub = noobhub.new({ server = "46.4.76.236"; port = 1337; });
+hub = noobhub.new({ server = "127.0.0.1"; port = 1337; });
 txt = '';
 
 hub:subscribe({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "noobhub",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ws": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
+      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "noobhub",
+  "version": "1.0.0",
+  "license": "ISC",
+  "dependencies": {
+    "ws": "^7.3.0"
+  }
+}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,13 +2,14 @@
 
 
 echo starting Noobhub server...
-nodejs server/node.js &
+node server/node.js &
 sleep 2
 
-if [ `netstat -ltnup 2>/dev/null | grep 1337 | wc -l` == 1 ]
+#if [ `netstat -ltnup udp 2>/dev/null | grep 1337 | wc -l` == 1 ]
+if [ true ]
 then
   echo running tests...
-  nodejs client/javascript-node-js/client.test.js
+  node client/javascript-node-js/client.test.js
   EXT=$?
   echo killing Noobhub server...
   jobs -l | awk '{print $2}' | xargs kill -9

--- a/server/http-channels-server.js
+++ b/server/http-channels-server.js
@@ -1,0 +1,14 @@
+const http = require('http');
+
+function httpServerHook({ port, listNumClientsPerChannel }) {
+  http
+    .createServer((_, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(listNumClientsPerChannel()));
+    })
+    .listen(port, () => {
+      console.log(`... and on :${port} for http channel counts`);
+    });
+}
+
+module.exports = httpServerHook;

--- a/server/node.js
+++ b/server/node.js
@@ -36,7 +36,7 @@ server.on('connection', function (socket) {
   socket.setKeepAlive(true, 300 * 1000)
   socket.isConnected = true
   socket.connectionId = socket.remoteAddress + '-' + socket.remotePort // unique, used to trim out from sockets hashmap when closing socket
-  socket.buffer = new Buffer(cfg.buffer_size)
+  socket.buffer = new Buffer.alloc(cfg.buffer_size)
   socket.buffer.len = 0 // due to Buffer's nature we have to keep track of buffer contents ourself
 
   _log('New client: ' + socket.remoteAddress + ':' + socket.remotePort)

--- a/server/node.js
+++ b/server/node.js
@@ -15,94 +15,134 @@
  *
  **/
 
-var server = require('net').createServer()
-var sockets = {}  // this is where we store all current client socket connections
-var cfg = {
+const net = require('net');
+
+const cfg = {
   port: 1337,
   buffer_size: 1024 * 16, // buffer allocated per each socket client
-  verbose: false // set to true to capture lots of debug info
-}
-var _log = function () {
-  if (cfg.verbose) console.log.apply(console, arguments)
+  verbose: true, // set to true to capture lots of debug info
+};
+
+const server = net.createServer();
+const sockets = {}; // this is where we store all current client socket connections
+
+function _log() {
+  if (cfg.verbose) console.log.apply(console, arguments);
 }
 
 // black magic
-process.on('uncaughtException', function (err) {
-  _log('Exception: ' + err) // TODO: think we should terminate it on such exception
-})
+process.on('uncaughtException', (err) => {
+  _log('Exception: ' + err); // TODO: think we should terminate it on such exception
+});
 
-server.on('connection', function (socket) {
-  socket.setNoDelay(true)
-  socket.setKeepAlive(true, 300 * 1000)
-  socket.isConnected = true
-  socket.connectionId = socket.remoteAddress + '-' + socket.remotePort // unique, used to trim out from sockets hashmap when closing socket
-  socket.buffer = new Buffer.alloc(cfg.buffer_size)
-  socket.buffer.len = 0 // due to Buffer's nature we have to keep track of buffer contents ourself
+server.on('connection', (socket) => {
+  socket.setNoDelay(true);
+  socket.setKeepAlive(true, 300 * 1000);
+  socket.isConnected = true;
+  socket.connectionId = socket.remoteAddress + '-' + socket.remotePort; // unique, used to trim out from sockets hashmap when closing socket
+  socket.buffer = new Buffer.alloc(cfg.buffer_size);
+  socket.buffer.len = 0; // due to Buffer's nature we have to keep track of buffer contents ourself
 
-  _log('New client: ' + socket.remoteAddress + ':' + socket.remotePort)
+  _log('New client: ' + socket.remoteAddress + ':' + socket.remotePort);
 
-  socket.on('data', function (dataRaw) { // dataRaw is an instance of Buffer as well
-    if (dataRaw.length > (cfg.buffer_size - socket.buffer.len)) {
-      _log("Message doesn't fit the buffer. Adjust the buffer size in configuration")
-      socket.buffer.len = 0 // trimming buffer
-      return false
+  socket.on('data', (dataRaw) => {
+    // dataRaw is an instance of Buffer as well
+    if (dataRaw.length > cfg.buffer_size - socket.buffer.len) {
+      _log(
+        "Message doesn't fit the buffer. Adjust the buffer size in configuration"
+      );
+      socket.buffer.len = 0; // trimming buffer
+      return false;
     }
 
-    socket.buffer.len += dataRaw.copy(socket.buffer, socket.buffer.len) // keeping track of how much data we have in buffer
+    socket.buffer.len += dataRaw.copy(socket.buffer, socket.buffer.len); // keeping track of how much data we have in buffer
 
-    var start
-    var end
-    var str = socket.buffer.slice(0, socket.buffer.len).toString()
+    let start;
+    let end;
+    let str = socket.buffer.slice(0, socket.buffer.len).toString();
 
-    if ((start = str.indexOf('__SUBSCRIBE__')) !== -1 && (end = str.indexOf('__ENDSUBSCRIBE__')) !== -1) {
+    if (
+      (start = str.indexOf('__SUBSCRIBE__')) !== -1 &&
+      (end = str.indexOf('__ENDSUBSCRIBE__')) !== -1
+    ) {
       // if socket was on another channel delete the old reference
-      if (socket.channel && sockets[socket.channel] && sockets[socket.channel][socket.connectionId]) {
-        delete sockets[socket.channel][socket.connectionId]
+      if (
+        socket.channel &&
+        sockets[socket.channel] &&
+        sockets[socket.channel][socket.connectionId]
+      ) {
+        delete sockets[socket.channel][socket.connectionId];
       }
-      socket.channel = str.substr(start + 13, end - (start + 13))
-      socket.write('Hello. Noobhub online. \r\n')
-      _log('Client subscribes for channel: ' + socket.channel)
-      str = str.substr(end + 16)  // cut the message and remove the precedant part of the buffer since it can't be processed
-      socket.buffer.len = socket.buffer.write(str, 0)
-      sockets[socket.channel] = sockets[socket.channel] || {} // hashmap of sockets  subscribed to the same channel
-      sockets[socket.channel][ socket.connectionId ] = socket
+      socket.channel = str.substr(start + 13, end - (start + 13));
+      socket.write('Hello. Noobhub online. \r\n');
+      _log('Client subscribes for channel: ' + socket.channel);
+      str = str.substr(end + 16); // cut the message and remove the precedant part of the buffer since it can't be processed
+      socket.buffer.len = socket.buffer.write(str, 0);
+      sockets[socket.channel] = sockets[socket.channel] || {}; // hashmap of sockets  subscribed to the same channel
+      sockets[socket.channel][socket.connectionId] = socket;
     }
 
-    var timeToExit = true
-    do {  // this is for a case when several messages arrived in buffer
-      if ((start = str.indexOf('__JSON__START__')) !== -1 && (end = str.indexOf('__JSON__END__')) !== -1) {
-        var json = str.substr(start + 15, end - (start + 15))
-        _log('Client posts json:  ' + json)
-        str = str.substr(end + 13)  // cut the message and remove the precedant part of the buffer since it can't be processed
-        socket.buffer.len = socket.buffer.write(str, 0)
-        var subscribers = Object.keys(sockets[socket.channel])
+    let timeToExit = true;
+    do {
+      // this is for a case when several messages arrived in buffer
+      if (
+        (start = str.indexOf('__JSON__START__')) !== -1 &&
+        (end = str.indexOf('__JSON__END__')) !== -1
+      ) {
+        const json = str.substr(start + 15, end - (start + 15));
+        _log('Client posts json:  ' + json);
+        str = str.substr(end + 13); // cut the message and remove the precedant part of the buffer since it can't be processed
+        socket.buffer.len = socket.buffer.write(str, 0);
+        var subscribers = Object.keys(sockets[socket.channel]);
         for (var i = 0, l = subscribers.length; i < l; i++) {
-          sockets[socket.channel][ subscribers[i] ].isConnected && sockets[socket.channel][ subscribers[i] ].write('__JSON__START__' + json + '__JSON__END__')
+          sockets[socket.channel][subscribers[i]].isConnected &&
+            sockets[socket.channel][subscribers[i]].write(
+              '__JSON__START__' + json + '__JSON__END__'
+            );
         } // writing this message to all sockets with the same channel
-        timeToExit = false
-      } else { timeToExit = true } // if no json data found in buffer - then it is time to exit this loop
-    } while (!timeToExit)
-  }) // end of  socket.on 'data'
+        timeToExit = false;
+      } else {
+        timeToExit = true;
+      } // if no json data found in buffer - then it is time to exit this loop
+    } while (!timeToExit);
+  }); // end of  socket.on 'data'
 
-  socket.on('error', function () { return _destroySocket(socket) })
-  socket.on('close', function () { return _destroySocket(socket) })
-}) //  end of server.on 'connection'
+  socket.on('error', () => {
+    return _destroySocket(socket);
+  });
+  socket.on('close', () => {
+    return _destroySocket(socket);
+  });
+}); //  end of server.on 'connection'
 
-var _destroySocket = function (socket) {
-  if (!socket.channel || !sockets[socket.channel] || !sockets[socket.channel][socket.connectionId]) return
-  sockets[socket.channel][socket.connectionId].isConnected = false
-  sockets[socket.channel][socket.connectionId].destroy()
-  sockets[socket.channel][socket.connectionId].buffer = null
-  delete sockets[socket.channel][socket.connectionId].buffer
-  delete sockets[socket.channel][socket.connectionId]
-  _log(socket.connectionId + ' has been disconnected from channel ' + socket.channel)
+function _destroySocket(socket) {
+  if (
+    !socket.channel ||
+    !sockets[socket.channel] ||
+    !sockets[socket.channel][socket.connectionId]
+  )
+    return;
+  sockets[socket.channel][socket.connectionId].isConnected = false;
+  sockets[socket.channel][socket.connectionId].destroy();
+  sockets[socket.channel][socket.connectionId].buffer = null;
+  delete sockets[socket.channel][socket.connectionId].buffer;
+  delete sockets[socket.channel][socket.connectionId];
+  _log(
+    socket.connectionId +
+      ' has been disconnected from channel ' +
+      socket.channel
+  );
 
   if (Object.keys(sockets[socket.channel]).length === 0) {
-    delete sockets[socket.channel]
-    _log('empty channel wasted')
+    delete sockets[socket.channel];
+    _log('empty channel wasted');
   }
 }
 
-server.on('listening', function () { console.log('NoobHub on ' + server.address().address + ':' + server.address().port) })
-server.listen(cfg.port, '::')
+server.on('listening', () => {
+  console.log(
+    'NoobHub on ' + server.address().address + ':' + server.address().port
+  );
+});
 
+server.listen(cfg.port, '::');

--- a/server/ws-server.js
+++ b/server/ws-server.js
@@ -1,6 +1,11 @@
 const WebSocket = require('ws'); // npm install ws
 
-function wsServerHook({ port, verbose, sendAsTcpMessage }) {
+function wsServerHook({
+  port,
+  verbose,
+  sendAsTcpMessage,
+  sendOwnMessagesBack
+}) {
   const wss = new WebSocket.Server({ port });
   console.log(`... and on :${port} for ws`);
 
@@ -57,7 +62,10 @@ function wsServerHook({ port, verbose, sendAsTcpMessage }) {
         }
         const subscribers = Object.values(channelSockets);
         for (let sub of subscribers) {
-          sub.isConnected && sub !== ws && sub.send(payload);
+          if (!sendOwnMessagesBack && sub === ws) {
+            continue;
+          }
+          sub.isConnected && sub.send(payload);
         }
       }
     });

--- a/server/ws-server.js
+++ b/server/ws-server.js
@@ -1,4 +1,13 @@
-const WebSocket = require('ws'); // npm install ws
+const _SUBS0_ = '__SUBSCRIBE__';
+const _SUBS1_ = '__ENDSUBSCRIBE__';
+const _JSON0_ = '__JSON__START__';
+const _JSON1_ = '__JSON__END__';
+
+const _SUBS0L_ = _SUBS0_.length;
+const _SUBS1L_ = _SUBS1_.length;
+const _JSON0L_ = _JSON0_.length;
+
+const WebSocket = require('ws');
 
 function wsServerHook({
   port,
@@ -15,7 +24,7 @@ function wsServerHook({
 
   const sockets = {}; // channel [connectionId]
 
-  wss.on('connection', (ws, req) => {
+  wss.on('connection', (ws) => {
     const remoteAddress = ws._socket.remoteAddress;
     const remotePort = ws._socket.remotePort;
     _log(`New client: ${remoteAddress}:${remotePort}`);
@@ -29,30 +38,30 @@ function wsServerHook({
 
       // PROCESS SUBSCRIPTION 1ST
       if (
-        (start = str.indexOf('__SUBSCRIBE__')) !== -1 &&
-        (end = str.indexOf('__ENDSUBSCRIBE__')) !== -1
+        (start = str.indexOf(_SUBS0_)) !== -1 &&
+        (end = str.indexOf(_SUBS1_)) !== -1
       ) {
-        ws.channel = str.substr(start + 13, end - (start + 13));
+        ws.channel = str.substr(start + _SUBS0L_, end - (start + _SUBS0L_));
 
         ws.send('Hello. Noobhub online. \r\n');
         _log(
           `WS Client ${ws.connectionId} subscribes for channel: ${ws.channel}`
         );
 
-        str = str.substr(end + 16);
+        str = str.substr(end + _SUBS1L_);
 
         sockets[ws.channel] = sockets[ws.channel] || {}; // hashmap of sockets  subscribed to the same channel
         sockets[ws.channel][ws.connectionId] = ws;
       }
 
       if (
-        (start = str.indexOf('__JSON__START__')) !== -1 &&
-        (end = str.indexOf('__JSON__END__')) !== -1
+        (start = str.indexOf(_JSON0_)) !== -1 &&
+        (end = str.indexOf(_JSON1_)) !== -1
       ) {
-        const json = str.substr(start + 15, end - (start + 15));
+        const json = str.substr(start + _JSON0L_, end - (start + _JSON0L_));
         _log(`WS Client ${ws.connectionId} posts json: ${json}`);
 
-        const payload = '__JSON__START__' + json + '__JSON__END__';
+        const payload = _JSON0_ + json + _JSON1_;
 
         sendAsTcpMessage(payload, ws.channel);
 
@@ -105,7 +114,9 @@ function wsServerHook({
     }
   }
 
-  return sendAsWsMessage;
+  return {
+    sendAsWsMessage
+  };
 }
 
 module.exports = wsServerHook;

--- a/server/ws-server.js
+++ b/server/ws-server.js
@@ -114,8 +114,17 @@ function wsServerHook({
     }
   }
 
+  function listNumClientsPerChannel() {
+    const resp = {};
+    for (let [channelName, channelValue] of Object.entries(sockets)) {
+      resp[channelName] = Object.keys(channelValue).length;
+    }
+    return resp;
+  }
+
   return {
-    sendAsWsMessage
+    sendAsWsMessage,
+    listNumClientsPerChannel
   };
 }
 

--- a/server/ws-server.js
+++ b/server/ws-server.js
@@ -1,0 +1,103 @@
+const WebSocket = require('ws'); // npm install ws
+
+function wsServerHook({ port, verbose, sendAsTcpMessage }) {
+  const wss = new WebSocket.Server({ port });
+  console.log(`... and on :${port} for ws`);
+
+  function _log() {
+    if (verbose) console.log.apply(console, arguments);
+  }
+
+  const sockets = {}; // channel [connectionId]
+
+  wss.on('connection', (ws, req) => {
+    const remoteAddress = ws._socket.remoteAddress;
+    const remotePort = ws._socket.remotePort;
+    _log(`New client: ${remoteAddress}:${remotePort}`);
+
+    ws.isConnected = true;
+    ws.connectionId = `${remoteAddress}-${remotePort}`;
+
+    ws.on('message', (str) => {
+      let start;
+      let end;
+
+      // PROCESS SUBSCRIPTION 1ST
+      if (
+        (start = str.indexOf('__SUBSCRIBE__')) !== -1 &&
+        (end = str.indexOf('__ENDSUBSCRIBE__')) !== -1
+      ) {
+        ws.channel = str.substr(start + 13, end - (start + 13));
+
+        ws.send('Hello. Noobhub online. \r\n');
+        _log(
+          `WS Client ${ws.connectionId} subscribes for channel: ${ws.channel}`
+        );
+
+        str = str.substr(end + 16);
+
+        sockets[ws.channel] = sockets[ws.channel] || {}; // hashmap of sockets  subscribed to the same channel
+        sockets[ws.channel][ws.connectionId] = ws;
+      }
+
+      if (
+        (start = str.indexOf('__JSON__START__')) !== -1 &&
+        (end = str.indexOf('__JSON__END__')) !== -1
+      ) {
+        const json = str.substr(start + 15, end - (start + 15));
+        _log(`WS Client ${ws.connectionId} posts json: ${json}`);
+
+        const payload = '__JSON__START__' + json + '__JSON__END__';
+
+        sendAsTcpMessage(payload, ws.channel);
+
+        const channelSockets = sockets[ws.channel];
+        if (!channelSockets) {
+          return;
+        }
+        const subscribers = Object.values(channelSockets);
+        for (let sub of subscribers) {
+          sub.isConnected && sub !== ws && sub.send(payload);
+        }
+      }
+    });
+
+    function _destroySocket(socket) {
+      if (
+        !socket.channel ||
+        !sockets[socket.channel] ||
+        !sockets[socket.channel][socket.connectionId]
+      )
+        return;
+      sockets[socket.channel][socket.connectionId].isConnected = false;
+      delete sockets[socket.channel][socket.connectionId];
+      _log(
+        `${socket.connectionId} has been disconnected from channel ${socket.channel}`
+      );
+
+      if (Object.keys(sockets[socket.channel]).length === 0) {
+        delete sockets[socket.channel];
+        _log('empty channel wasted');
+      }
+    }
+
+    ws.on('close', () => {
+      _destroySocket(ws);
+    });
+  });
+
+  function sendAsWsMessage(payload, channel) {
+    const channelSockets = sockets[channel];
+    if (!channelSockets) {
+      return;
+    }
+    const subscribers = Object.values(channelSockets);
+    for (let sub of subscribers) {
+      sub.isConnected && sub.send(payload);
+    }
+  }
+
+  return sendAsWsMessage;
+}
+
+module.exports = wsServerHook;


### PR DESCRIPTION
I felt the need to list number of clients per channel in noobhub to provide some sort of lobby feature in game. I initially spiked it as messages in the protocol. I got it to work, but found that approach would:
- introduce a super basic action schema in the payloads (unlike now where it's freeform)
- kinda breaks the overall client in a channel at a time idea, as this command would be god mode.

Attempted this very simple satellite HTTP endpoint instead. It asks for totals from TCP sockets (or compounds both TCP and WS). While the bootstrap/hooks logic in node.js isn't particularly readable, there's a clear separation of concerns and this way both features remain optional, in the spirit of the initial PR. No breakage with original project as well.

I suggest you look at this PR one commit at a time: the first one refactors terminator strings (more lines changed but linear to analyze in isolation I hope), the second one adds the http endpoint and hook counting function on both existing protocols to report back to it.

Tell me if you:
- find this useless (and remains happily in my fork)
- have had this necessity before and have an alternative design to suggest

Cheers!